### PR TITLE
Build Openlibm with Mini-OS CFLAGS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,5 +12,5 @@ cd ../../..
 rm -rf ${LIBM}
 tar -zxf ${LIBM_ARCHIVE}
 cd ${LIBM}
-make
+make CFLAGS="$CFLAGS $(PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig pkg-config libminios-xen --cflags)"
 ${SUDO} make install prefix=${PREFIX}

--- a/vars.sh
+++ b/vars.sh
@@ -6,10 +6,10 @@ if [ "${PREFIX}" = "" ]; then
   fi
 fi
 
-MINIOS=minios-v0.4.2
+MINIOS=minios-v0.4.3
 MINIOS_ARCHIVE=${MINIOS}.tar.gz
 MINIOS_URL=https://github.com/talex5/xen/archive/${MINIOS_ARCHIVE}
 
-LIBM=openlibm-0.4
-LIBM_ARCHIVE=v0.4.tar.gz
-LIBM_URL=https://github.com/JuliaLang/openlibm/archive/${LIBM_ARCHIVE}
+LIBM=openlibm-0.4-tal1
+LIBM_ARCHIVE=v0.4-tal1.tar.gz
+LIBM_URL=https://github.com/talex5/openlibm/archive/${LIBM_ARCHIVE}


### PR DESCRIPTION
In particular, use -mno-red-zone on x86_64.

I haven't noticed any specific problems, but this is probably a good idea...
