### PR TITLE
[Tracking] Depend on minios-xen opam package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 This repository contains the scripts to install the library dependencies required
-by the MirageOS Xen backend.  It contains:
+by the MirageOS Xen backend:
 
 * An unofficial fork of Mini-OS, a small operating system kernel that
   runs as a Xen guest. Mini-OS is part of Xen, but for convenience the
   non-Mini-OS parts have been deleted for this library.
-  <https://github.com/talex5/xen/releases/tag/minios-v0.2>
+  <https://github.com/talex5/mini-os>
 
 * OpenLibM, from the upstream master, but forked in order to have a
   stable tag while waiting for an upstream release.
-  <https://github.com/talex5/openlibm/releases/tag/v0.3.1-tal1>
+  <https://github.com/talex5/openlibm>

--- a/fetch.sh
+++ b/fetch.sh
@@ -2,5 +2,4 @@
 
 . ./vars.sh
 
-if [ ! -e ${MINIOS_ARCHIVE} ]; then curl -OL ${MINIOS_URL}; fi
 if [ ! -e ${LIBM_ARCHIVE} ]; then curl -OL ${LIBM_URL}; fi

--- a/install.sh
+++ b/install.sh
@@ -2,13 +2,6 @@
 
 . ./vars.sh
 
-rm -rf xen-${MINIOS}
-tar -zxf ${MINIOS_ARCHIVE}
-cd xen-${MINIOS}/extras/mini-os
-make debug=n
-${SUDO} make install LIBDIR=${PREFIX}/lib INCLUDEDIR=${PREFIX}/include
-cd ../../..
-
 rm -rf ${LIBM}
 tar -zxf ${LIBM_ARCHIVE}
 cd ${LIBM}

--- a/opam
+++ b/opam
@@ -9,3 +9,4 @@ build: [
 ]
 remove: []
 os: ["linux"]
+depends: ["minios-xen"]

--- a/vars.sh
+++ b/vars.sh
@@ -6,10 +6,6 @@ if [ "${PREFIX}" = "" ]; then
   fi
 fi
 
-MINIOS=minios-v0.6
-MINIOS_ARCHIVE=${MINIOS}.tar.gz
-MINIOS_URL=https://github.com/talex5/xen/archive/${MINIOS_ARCHIVE}
-
 LIBM=openlibm-0.4.1-tal1
 LIBM_ARCHIVE=v0.4.1-tal1.tar.gz
 LIBM_URL=https://github.com/talex5/openlibm/archive/${LIBM_ARCHIVE}


### PR DESCRIPTION
Before, we downloaded the archive and installed it manually. Making it a separate opam package makes it easier to run developer versions of MiniOS.

Use this branch if you want to test the Git version. Do not merge until there is a release of the separate MiniOS package in the opam repository.