### PR TITLE
Use upstream v0.5.4 of openlibm

### DIFF
--- a/vars.sh
+++ b/vars.sh
@@ -6,6 +6,6 @@ if [ "${PREFIX}" = "" ]; then
   fi
 fi
 
-LIBM=openlibm-0.4.1-tal1
-LIBM_ARCHIVE=v0.4.1-tal1.tar.gz
-LIBM_URL=https://github.com/talex5/openlibm/archive/${LIBM_ARCHIVE}
+LIBM=openlibm-0.5.4
+LIBM_ARCHIVE=v0.5.4.tar.gz
+LIBM_URL=https://github.com/JuliaLang/openlibm/archive/${LIBM_ARCHIVE}


### PR DESCRIPTION
This fixes #16 which currently breaks the Xen unikernel builds on alpine.

However the previous version had commits from this tag:

https://github.com/talex5/openlibm/commits/v0.4.1-tal1

which may or may not have equivalents upstream. I doubt the CI for this repo is capable of testing ARM.

Signed-off-by: David Scott <dave@recoil.org>