### PR TITLE
openlibm installs in include/openlibm

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,5 +5,6 @@
 rm -rf ${LIBM}
 tar -zxf ${LIBM_ARCHIVE}
 cd ${LIBM}
+patch -p1 < ../patch-1.diff
 make CFLAGS="$CFLAGS $(PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig pkg-config libminios-xen --cflags)" libopenlibm.a
 ${SUDO} make install prefix=${PREFIX}

--- a/patch-1.diff
+++ b/patch-1.diff
@@ -1,0 +1,9 @@
+--- openlibm-0.5.4.orig/openlibm.pc.in	2017-06-12 10:51:49.000000000 +0100
++++ openlibm-0.5.4/openlibm.pc.in	2017-06-12 10:51:55.000000000 +0100
+@@ -1,5 +1,5 @@
+ exec_prefix=${prefix}
+-includedir=${prefix}/include
++includedir=${prefix}/include/openlibm
+ libdir=${exec_prefix}/lib
+ 
+ Name: openlibm


### PR DESCRIPTION
The bundled openlibm.pc file sets the includedir to /include.

Signed-off-by: David Scott <dave@recoil.org>