### PR TITLE
Re-add the header `complex.h`

### DIFF
--- a/complex.h
+++ b/complex.h
@@ -1,0 +1,10 @@
+#ifndef __COMPLEX_H_
+#define	__COMPLEX_H_
+
+#define complex		_Complex
+#define _Complex_I	(__extension__ 1.0iF)
+#define I _Complex_I
+
+#include <openlibm_complex.h>
+
+#endif

--- a/install.sh
+++ b/install.sh
@@ -8,3 +8,5 @@ cd ${LIBM}
 patch -p1 < ../patch-1.diff
 make CFLAGS="$CFLAGS $(PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig pkg-config libminios-xen --cflags)" libopenlibm.a
 ${SUDO} make install prefix=${PREFIX}
+cd ..
+${SUDO} cp complex.h ${PREFIX}/include


### PR DESCRIPTION
As originally noted in

https://github.com/talex5/openlibm/commit/989b8cf0163da95bc0a5d144c861e9f6486200a9

Openlibm expects the system to have one already, but MiniOS doesn't.

Note this is only necessary because ctypes depends on it.

Signed-off-by: David Scott <dave@recoil.org>